### PR TITLE
Pin jsrsasign to last version w/o breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "lodash": "^3.10.1",
     "base64url": "^1.0.4",
-    "jsrsasign": "^4.8.3",
+    "jsrsasign": "4.9.2",
     "jwa": "^1.0.0",
     "valid-url": "^1.0.9"
   }


### PR DESCRIPTION
Short term fix for #5, because urgency is high, but a long-term solution is necessary.
