### PR TITLE
Use new jsrsasign/jsjws API for JWK verification

### DIFF
--- a/lib/JWT.js
+++ b/lib/JWT.js
@@ -413,11 +413,11 @@ JWT.decode = function (token, secret) {
         // exposed in the node version of jsrsasign so we can't access it.
         //
         // Using jsjws is stopgap until there's a cleaner way.
-        var jws = new jsrsasign.jws.JWS()
         var hN = base64url.decode(secret.n, 'hex')
         var hE = base64url.decode(secret.e, 'hex')
+        var pubkey = jsrsasign.KEYUTIL.getKey({ n: hN, e: hE })
 
-        verified = jws.verifyJWSByNE(token, hN, hE)
+        verified = jsrsasign.jws.JWS.verify(token, pubkey)
       }
 
       if (!verified) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "lodash": "^3.10.1",
     "base64url": "^1.0.4",
-    "jsrsasign": "^4.8.3",
+    "jsrsasign": "^5.0.0",
     "jwa": "^1.0.0",
     "valid-url": "^1.0.9"
   }


### PR DESCRIPTION
Fixes #5

Release required after merge to ensure dependent packages function properly.
